### PR TITLE
Update duct/logger to 0.2.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [duct/core "0.6.1"]
                  [aleph "0.4.3"]
-                 [duct/logger "0.1.1"]
+                 [duct/logger "0.2.1"]
                  [integrant "0.6.1"]]
   :profiles
   {:dev {:dependencies [[clj-http "2.1.0"]]}})

--- a/test/duct/server/http/aleph_test.clj
+++ b/test/duct/server/http/aleph_test.clj
@@ -9,7 +9,7 @@
 
 (defrecord TestLogger [logs]
   logger/Logger
-  (-log [_ level ns-str file line event data]
+  (-log [_ level ns-str file line id event data]
     (swap! logs conj [event data])))
 
 (duct/load-hierarchy)


### PR DESCRIPTION
Since `module.web` depends on `[duct/logger 0.2.1]`, it is reasonable to update server.http.aleph's dependency too. Otherwise, no way to swap between `jetty` or `aleph` or other implmentation. 