### PR TITLE
Update Aleph dependency to 0.4.6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0-beta3"]
                  [duct/core "0.6.1"]
-                 [aleph "0.4.3"]
+                 [aleph "0.4.6"]
                  [duct/logger "0.2.1"]
                  [integrant "0.6.1"]]
   :profiles


### PR DESCRIPTION
There are lots of improvements and fixes in Aleph 0.4.6. I've been using this with 0.4.6 and things seem to be working, though my usage has been pretty minimal so far.

https://github.com/ztellman/aleph/compare/0.4.3...0.4.6
https://github.com/ztellman/aleph/blob/master/CHANGES.md#046